### PR TITLE
Add wc_query_string_form_fields() to customEscapingFunctions

### DIFF
--- a/src/WooCommerce-Core/ruleset.xml
+++ b/src/WooCommerce-Core/ruleset.xml
@@ -20,7 +20,7 @@
 
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
-			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_selected,wc_kses_notice,wc_esc_json" />
+			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_selected,wc_kses_notice,wc_esc_json,wc_query_string_form_fields" />
 		</properties>
 	</rule>
 


### PR DESCRIPTION
The output produced by wc_query_string_form_fields() is already escaped
so it is safe to add this function to customEscapingFunctions.