### PR TITLE
Add ^ before version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "wp-coding-standards/wpcs": "2.3.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
-        "phpcompatibility/phpcompatibility-wp": "2.1.0"
+        "wp-coding-standards/wpcs": "^2.3.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1.0"
     }
 }


### PR DESCRIPTION
Removed strict version checks. 

If a project has already been using PHPCS, e.g. `dealerdirect/phpcodesniffer-composer-installer` which is at `0.7.1`, its `composer.lock` prevents this being installed, even if `dealerdirect/phpcodesniffer-composer-installer` is set to `*`.

It certainly makes sense to allow patch updates, and I don't think I'd worry about minor anyway.