### PR TITLE
Tweak/comment hooks

### DIFF
--- a/src/WooCommerce/Sniffs/Commenting/CommentHooksSniff.php
+++ b/src/WooCommerce/Sniffs/Commenting/CommentHooksSniff.php
@@ -58,25 +58,25 @@ class CommentHooksSniff implements Sniff
             return;
         }
 
-        $previous_comment = $phpcsFile->findPrevious( Tokens::$commentTokens, ( $stack_ptr - 1 ) );
+        $previous_comment = $phpcsFile->findPrevious(Tokens::$commentTokens, ($stack_ptr - 1));
 
-        if ( false !== $previous_comment ) {
-            if ( ( $tokens[ $previous_comment ]['line'] + 1 ) === $tokens[ $stack_ptr ]['line'] ) {
+        if (false !== $previous_comment) {
+            if (($tokens[ $previous_comment ]['line'] + 1) === $tokens[ $stack_ptr ]['line']) {
                 return;
             } else {
-                $next_non_whitespace = $phpcsFile->findNext( \T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
+                $next_non_whitespace = $phpcsFile->findNext(\T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true);
 
-                if ( false === $next_non_whitespace || $tokens[ $next_non_whitespace ]['line'] === $tokens[ $stack_ptr ]['line'] ) {
+                if (false === $next_non_whitespace || $tokens[ $next_non_whitespace ]['line'] === $tokens[ $stack_ptr ]['line']) {
                     // No non-whitespace found or next non-whitespace is on same line as hook call.
                     return;
                 }
-                unset( $next_non_whitespace );
+                unset($next_non_whitespace);
             }
         }
 
         // Found hooks but no doc comment.
-        $phpcsFile->addWarning(
-            sprintf( 'Documentation/comment needed for hook to explain what the hook does: %s', $tokens[ $stack_ptr ]['content'] ),
+        $phpcsFile->addError(
+            sprintf('Documentation/comment needed for hook to explain what the hook does: %s', $tokens[ $stack_ptr ]['content']),
             $stack_ptr,
             'MissingHooksComment'
         );


### PR DESCRIPTION
This PR tweaks the "hooks" sniff to require a docblock style comment and also `@since` tag.

Closes 21-gh-woocommerce/platform-private

**Testing:**

* Use a Git a repo that is using a pre-commit hook that fires your PHPCS check with this PR used.
* Modify a PHP file and add `do_action( 'Woo' );`.
* Run `git commit -am "Testing sniff"`;
* You should see PHPCS warning not allowing you to commit this change without a doc comment.
* Now add a regular `//` style comment to that hook and re-run the commit. This time it should not allow you to commit without docblock style comment.
* Now add a proper docblock style comment without `@since` and try to commit again. This time it should not allow you to commit without the `@since` tag.
* Do the same test but with `apply_filters` hook. Modify a PHP file and add `$filtered = apply_filters( 'Woo', true );`.
* Run `git commit -am "Testing sniff"`;
* Repeat the steps above to test each error.