### PR TITLE
Add validation for since tag version

### DIFF
--- a/src/WooCommerce/Sniffs/Commenting/CommentHooksSniff.php
+++ b/src/WooCommerce/Sniffs/Commenting/CommentHooksSniff.php
@@ -68,7 +68,6 @@ class CommentHooksSniff implements Sniff
             }
 
             if (true === $correctly_placed) {
-
                 if (\T_COMMENT === $tokens[ $previous_comment ]['code']) {
                     $phpcsFile->addError(
                         'A "hook" comment must be a "/**" style docblock comment.',
@@ -83,6 +82,17 @@ class CommentHooksSniff implements Sniff
                     // Iterate through each comment to check for "@since" tag.
                     foreach ($tokens[ $comment_start ]['comment_tags'] as $tag) {
                         if ($tokens[$tag]['content'] === '@since') {
+                            // Check if there is a version after the @since tag.
+                            if (! preg_match('/\d+\.\d+\.?\d?/', $tokens[$tag+2]['content'])) {
+                                $phpcsFile->addError(
+                                    'A "@since" tag was found but no version declared. Required format <x.x> or <x.x.x>',
+                                    $stackPtr,
+                                    'MissingSinceVersionComment'
+                                );
+
+                                return;
+                            }
+
                             return;
                         }
                     }


### PR DESCRIPTION
This PR adds validation for the [at]since version to make sure they have supplied a valid version for that tag.

Closes #28 

Prereq:
Make sure you have this PR pulled down and that your global PHPCS is referencing this change.

Testing:

* Git clone `https://github.com/woocommerce/woocommerce`.
* Go to your cloned repo and modify the file `plugins/woocommerce/woocommerce.php`. Add a `do_action` or `apply_filters` hook with docblock. Add the `[at]since` tag without version. For example:
```
/**
 * Description
 *
 * @since
 */
do_action( 'hook' );
 ```
* Now in the root of your repo run `phpcs -s plugins/woocommerce/woocommerce.php`.
* Ensure you see the violation that no versions were supplied with the `[at]since` tag.
* Now add the version in either <x.x.x> or <x.x> format and run the sniff command again.
* This time you should see no violations.

Note:
I did not add the check for description as per the original #28 issue as this is already being picked up by the generic PEAR rules.

Task:
After approved and merged, we need to do a release and bump the woocommerce-sniffs version in WooCommerce-monorepo.