### PR TITLE
Update arrays definitions to follow modern CodeSniffer conventions

### DIFF
--- a/src/WooCommerce-Core/ruleset.xml
+++ b/src/WooCommerce-Core/ruleset.xml
@@ -17,13 +17,28 @@
 
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>
-			<property name="customSanitizingFunctions" type="array" value="wc_clean,wc_sanitize_tooltip,wc_format_decimal,wc_stock_amount,wc_sanitize_permalink,wc_sanitize_textarea" />
+            <property name="customSanitizingFunctions" type="array">
+                <element value="wc_clean" />
+                <element value="wc_sanitize_tooltip" />
+                <element value="wc_format_decimal" />
+                <element value="wc_stock_amount" />
+                <element value="wc_sanitize_permalink" />
+                <element value="wc_sanitize_textarea" />
+            </property>
 		</properties>
 	</rule>
 
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
-			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_selected,wc_kses_notice,wc_esc_json,wc_query_string_form_fields,wc_make_phone_clickable" />
+            <property name="customEscapingFunctions" type="array">
+                <element value="wc_help_tip" />
+                <element value="wc_sanitize_tooltip" />
+                <element value="wc_selected" />
+                <element value="wc_kses_notice" />
+                <element value="wc_esc_json" />
+                <element value="wc_query_string_form_fields" />
+                <element value="wc_make_phone_clickable" />
+            </property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
In the provided sniffs array contents are defined through the string property, which is deprecated by modern CodeSniffer versions and results in the following warnings:

```
DEPRECATED: Passing an array of values to a property using a comma-separated string
was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.
The deprecated syntax was used for property "customSanitizingFunctions"
for sniff "WordPress.Security.ValidatedSanitizedInput".
Pass array values via <element [key="..." ]value="..."> nodes instead.
DEPRECATED: Passing an array of values to a property using a comma-separated string
was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.
The deprecated syntax was used for property "customEscapingFunctions"
for sniff "WordPress.Security.EscapeOutput".
Pass array values via <element [key="..." ]value="..."> nodes instead.
```

This pull request updates definitions to follow the new format.

### Testing instructions

> [!NOTE]
> Composer supports retrieving dependencies from a branch, but it doesn't work for forked branches. Hence instructions require to overwrite installed version.

 - Checkout [woocommerce](https://github.com/woocommerce/woocommerce) repository.
 - Go to the `plugins/woocommerce` directory and run `composer install`
 - Run `./vendor/bin/phpcs` and notice the aforementioned errors
 - Replace `bin/composer/phpcs/vendor/woocommerce/woocommerce-sniffs/src` with the contents from this branch.
 - Run `./vendor/bin/phpcs`. The aforementioned errors will go away, but one remain, which is defined in the plugin's `phpcs.xml` 
