### PR TITLE
Add sniff to flag expensive get_available_variations() usage

### DIFF
--- a/src/WooCommerce/Sniffs/Functions/GetAvailableVariationsSniff.php
+++ b/src/WooCommerce/Sniffs/Functions/GetAvailableVariationsSniff.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Sniff to discourage expensive usage of WC_Product_Variable::get_available_variations().
+ */
+
+namespace WooCommerce\Sniffs\Functions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Flags calls to get_available_variations() that use the expensive 'array' return type.
+ *
+ * The default 'array' return type processes expensive data per variation: HTML generation,
+ * price calculations, image lookups, and formatting. For products with many variations,
+ * this creates significant overhead. The 'objects' return type is much lighter when
+ * full processed variation data isn't needed.
+ */
+class GetAvailableVariationsSniff implements Sniff
+{
+    /**
+     * The method name to check.
+     *
+     * @var string
+     */
+    const METHOD_NAME = 'get_available_variations';
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register(): array
+    {
+        return [T_STRING];
+    }
+
+    /**
+     * Processes this test when one of its tokens is encountered.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check if this is our target method name.
+        if (self::METHOD_NAME !== $tokens[$stackPtr]['content']) {
+            return;
+        }
+
+        // Ensure this is a method call (preceded by -> or ::).
+        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
+        if (false === $prevToken) {
+            return;
+        }
+
+        if (T_OBJECT_OPERATOR !== $tokens[$prevToken]['code']
+            && T_DOUBLE_COLON !== $tokens[$prevToken]['code']
+        ) {
+            return;
+        }
+
+        // Find the opening parenthesis.
+        $openParen = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+        if (false === $openParen || T_OPEN_PARENTHESIS !== $tokens[$openParen]['code']) {
+            return;
+        }
+
+        // Find what's inside the parentheses.
+        $closeParen = $tokens[$openParen]['parenthesis_closer'];
+        $firstArg = $phpcsFile->findNext(T_WHITESPACE, $openParen + 1, $closeParen, true);
+
+        // Case 1: No arguments - using default 'array'.
+        if (false === $firstArg) {
+            $phpcsFile->addWarning(
+                'get_available_variations() defaults to the expensive \'array\' return type. '
+                . 'Consider using \'objects\' if you only need WC_Product_Variation objects.',
+                $stackPtr,
+                'DefaultArrayReturn'
+            );
+            return;
+        }
+
+        // Case 2: Check if the argument is explicitly 'array'.
+        if (T_CONSTANT_ENCAPSED_STRING === $tokens[$firstArg]['code']) {
+            $argValue = trim($tokens[$firstArg]['content'], '\'"');
+            if ('array' === $argValue) {
+                $phpcsFile->addWarning(
+                    'get_available_variations(\'array\') is expensive for products with many variations. '
+                    . 'Consider using \'objects\' if you only need WC_Product_Variation objects.',
+                    $stackPtr,
+                    'ExplicitArrayReturn'
+                );
+            }
+        }
+    }
+}

--- a/src/WooCommerce/Sniffs/Functions/GetAvailableVariationsSniff.php
+++ b/src/WooCommerce/Sniffs/Functions/GetAvailableVariationsSniff.php
@@ -28,11 +28,14 @@ class GetAvailableVariationsSniff implements Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * Listens for object operators (->) which indicate instance method calls,
+     * rather than T_STRING which triggers for many token types.
+     *
      * @return array
      */
     public function register(): array
     {
-        return [T_STRING];
+        return [T_OBJECT_OPERATOR];
     }
 
     /**
@@ -45,25 +48,19 @@ class GetAvailableVariationsSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        // Find the method name after the operator.
+        $methodNamePtr = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+        if (false === $methodNamePtr || T_STRING !== $tokens[$methodNamePtr]['code']) {
+            return;
+        }
+
         // Check if this is our target method name.
-        if (self::METHOD_NAME !== $tokens[$stackPtr]['content']) {
+        if (self::METHOD_NAME !== $tokens[$methodNamePtr]['content']) {
             return;
         }
 
-        // Ensure this is a method call (preceded by -> or ::).
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
-        if (false === $prevToken) {
-            return;
-        }
-
-        if (T_OBJECT_OPERATOR !== $tokens[$prevToken]['code']
-            && T_DOUBLE_COLON !== $tokens[$prevToken]['code']
-        ) {
-            return;
-        }
-
-        // Find the opening parenthesis.
-        $openParen = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+        // Find the opening parenthesis to confirm this is a method call.
+        $openParen = $phpcsFile->findNext(T_WHITESPACE, $methodNamePtr + 1, null, true);
         if (false === $openParen || T_OPEN_PARENTHESIS !== $tokens[$openParen]['code']) {
             return;
         }
@@ -77,7 +74,7 @@ class GetAvailableVariationsSniff implements Sniff
             $phpcsFile->addWarning(
                 'get_available_variations() defaults to the expensive \'array\' return type. '
                 . 'Consider using \'objects\' if you only need WC_Product_Variation objects.',
-                $stackPtr,
+                $methodNamePtr,
                 'DefaultArrayReturn'
             );
             return;
@@ -90,7 +87,7 @@ class GetAvailableVariationsSniff implements Sniff
                 $phpcsFile->addWarning(
                     'get_available_variations(\'array\') is expensive for products with many variations. '
                     . 'Consider using \'objects\' if you only need WC_Product_Variation objects.',
-                    $stackPtr,
+                    $methodNamePtr,
                     'ExplicitArrayReturn'
                 );
             }

--- a/src/WooCommerce/Sniffs/Functions/GetAvailableVariationsSniff.php
+++ b/src/WooCommerce/Sniffs/Functions/GetAvailableVariationsSniff.php
@@ -35,7 +35,7 @@ class GetAvailableVariationsSniff implements Sniff
      */
     public function register(): array
     {
-        return [T_OBJECT_OPERATOR];
+        return [T_OBJECT_OPERATOR, T_DOUBLE_COLON];
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds `GetAvailableVariationsSniff` that warns when:
- `get_available_variations()` is called without arguments (defaults to expensive 'array' return type)
- `get_available_variations('array')` is called explicitly

The 'array' return type processes expensive data per variation: HTML generation, price calculations, image lookups, and formatting. For products with many variations, this creates significant overhead. The 'objects' return type is much lighter when full processed variation data isn't needed.

## Usage

The sniff triggers warnings (not errors) to encourage developers to consider whether they actually need the full processed variation data:

```
WARNING | get_available_variations() defaults to the expensive 'array' return type. 
        | Consider using 'objects' if you only need WC_Product_Variation objects.
```

### Suppressing warnings

When the 'array' return type is legitimately needed (e.g., for front-end display), suppress with:

```php
// phpcs:ignore WooCommerce.Functions.GetAvailableVariations.DefaultArrayReturn -- needed for front-end display
$variations = $product->get_available_variations();
```

## Test plan

Create a test PHP file with the following cases and run PHPCS against it:

```php
<?php
// Should warn: DefaultArrayReturn
$variations = $product->get_available_variations();

// Should warn: ExplicitArrayReturn
$variations = $product->get_available_variations('array');

// Should NOT warn - using 'objects'
$variations = $product->get_available_variations('objects');

// Should NOT warn - function with same name but not a method call
function get_available_variations() {}
get_available_variations();

// Should warn: DefaultArrayReturn - static call
$variations = WC_Product_Variable::get_available_variations();

// Should NOT warn - suppressed
// phpcs:ignore WooCommerce.Functions.GetAvailableVariations.DefaultArrayReturn
$variations = $product->get_available_variations();
```

Run: `vendor/bin/phpcs --standard=WooCommerce test.php`

Expected: Warnings on lines 3, 6, and 16. No warnings on lines 9, 12-13, and 19-20.

Partially fixes WOOPLUG-6106 / woocommerce/woocommerce#62686