### PR TITLE
Allow cross-reference comments as valid hook documentation

### DIFF
--- a/src/WooCommerce/Sniffs/Commenting/CommentHooksSniff.php
+++ b/src/WooCommerce/Sniffs/Commenting/CommentHooksSniff.php
@@ -79,6 +79,14 @@ class CommentHooksSniff implements Sniff
                 } elseif (\T_DOC_COMMENT_CLOSE_TAG === $tokens[ $previous_comment ]['code']) {
                     $comment_start = $phpcsFile->findPrevious(\T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ));
 
+                    // Accept "This filter/action is documented in ..." cross-reference comments
+                    // as a valid alternative to a full docblock. This follows the WordPress core
+                    // convention for hooks that are documented elsewhere.
+                    $comment_text = $phpcsFile->getTokensAsString($comment_start, ( $previous_comment - $comment_start + 1 ));
+                    if (preg_match('/This (filter|action) is documented in/', $comment_text)) {
+                        return;
+                    }
+
                     // Iterate through each comment to check for "@since" tag.
                     foreach ($tokens[ $comment_start ]['comment_tags'] as $tag) {
                         if ($tokens[$tag]['content'] === '@since') {


### PR DESCRIPTION
## Summary

- Recognize `/** This filter/action is documented in ... */` as a valid hook comment, following the WordPress core convention
- Removes the need for `phpcs:ignore` or `phpcs:disable` annotations when using cross-reference comments on hooks

Fixes https://github.com/woocommerce/woocommerce-sniffs/issues/37

## Context

The `CommentHooksSniff` requires every hook docblock to contain a `@since` tag. This causes false positives for the standard WordPress cross-reference pattern:

```php
/** This filter is documented in wp-includes/class-wp-query.php */
apply_filters( 'wp_query_search_exclusion_prefix', '-' );
```

WordPress core uses this convention when a hook appears in multiple locations — only one site carries the full docblock, and others cross-reference it. WooCommerce already uses this pattern in many places but each instance requires a suppression comment:

- `wc-stock-functions.php` — `phpcs:disable` around cross-referenced stock actions
- `OrderActionsRestController.php` — `phpcs:disable` around cross-referenced email actions
- `EditLock.php` — `phpcs:ignore` on the same line
- `EmailPreview.php` — `phpcs:ignore` on the same line
- `class-wc-rest-refunds-controller.php` — `phpcs:disable` / `phpcs:enable` block

This fix detects the cross-reference pattern and treats it as valid documentation, removing the need for suppression annotations.

See woocommerce/woocommerce#63760 for an example PR where this causes a CI failure.